### PR TITLE
Remove the redirect_uri parameter from token refresh

### DIFF
--- a/Source/OIDAuthState.m
+++ b/Source/OIDAuthState.m
@@ -410,7 +410,7 @@ static const NSUInteger kExpiryTimeTolerance = 60;
       initWithConfiguration:_lastAuthorizationResponse.request.configuration
                   grantType:OIDGrantTypeRefreshToken
           authorizationCode:nil
-                redirectURL:_lastAuthorizationResponse.request.redirectURL
+                redirectURL:nil
                    clientID:_lastAuthorizationResponse.request.clientID
                clientSecret:_lastAuthorizationResponse.request.clientSecret
                       scope:_lastAuthorizationResponse.request.scope

--- a/Source/OIDError.h
+++ b/Source/OIDError.h
@@ -385,4 +385,9 @@ typedef NS_ENUM(NSInteger, OIDErrorCodeOAuthRegistration) {
  */
 extern NSString *const OIDOAuthExceptionInvalidAuthorizationFlow;
 
+/*! @brief The text for the exception which occurs when a Token Request is constructed
+        with a null redirectURL for a grant_type that requires a nonnull Redirect
+ */
+extern NSString *const OIDOAuthExceptionInvalidTokenRequestNullRedirectURL;
+
 NS_ASSUME_NONNULL_END

--- a/Source/OIDError.m
+++ b/Source/OIDError.m
@@ -33,6 +33,9 @@ NSString *const OIDHTTPErrorDomain = @"org.openid.appauth.remote-http";
 NSString *const OIDOAuthExceptionInvalidAuthorizationFlow = @"An OAuth redirect was sent to a "
     "OIDAuthorizationFlowSession after it already completed.";
 
+NSString *const OIDOAuthExceptionInvalidTokenRequestNullRedirectURL = @"A OIDTokenRequest was "
+    "created with a grant_type that requires a redirectURL, but a null redirectURL was given";
+
 NSString *const OIDOAuthErrorResponseErrorKey = @"OIDOAuthErrorResponseErrorKey";
 
 NSString *const OIDOAuthErrorFieldError = @"error";

--- a/Source/OIDTokenRequest.h
+++ b/Source/OIDTokenRequest.h
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
     @remarks redirect_uri
     @see https://tools.ietf.org/html/rfc6749#section-4.1.3
  */
-@property(nonatomic, readonly) NSURL *redirectURL;
+@property(nonatomic, readonly, nullable) NSURL *redirectURL;
 
 /*! @brief The client identifier.
     @remarks client_id
@@ -127,7 +127,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                grantType:(NSString *)grantType
        authorizationCode:(nullable NSString *)code
-             redirectURL:(NSURL *)redirectURL
+             redirectURL:(nullable NSURL *)redirectURL
                 clientID:(NSString *)clientID
             clientSecret:(nullable NSString *)clientSecret
                   scopes:(nullable NSArray<NSString *> *)scopes
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                grantType:(NSString *)grantType
        authorizationCode:(nullable NSString *)code
-             redirectURL:(NSURL *)redirectURL
+             redirectURL:(nullable NSURL *)redirectURL
                 clientID:(NSString *)clientID
             clientSecret:(nullable NSString *)clientSecret
                    scope:(nullable NSString *)scope

--- a/Source/OIDTokenRequest.m
+++ b/Source/OIDTokenRequest.m
@@ -19,6 +19,7 @@
 #import "OIDTokenRequest.h"
 
 #import "OIDDefines.h"
+#import "OIDError.h"
 #import "OIDScopeUtilities.h"
 #import "OIDServiceConfiguration.h"
 #import "OIDURLQueryComponent.h"
@@ -95,7 +96,7 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                grantType:(NSString *)grantType
        authorizationCode:(nullable NSString *)code
-             redirectURL:(NSURL *)redirectURL
+             redirectURL:(nullable NSURL *)redirectURL
                 clientID:(NSString *)clientID
             clientSecret:(nullable NSString *)clientSecret
                   scopes:(nullable NSArray<NSString *> *)scopes
@@ -117,7 +118,7 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
 - (instancetype)initWithConfiguration:(OIDServiceConfiguration *)configuration
                grantType:(NSString *)grantType
        authorizationCode:(nullable NSString *)code
-             redirectURL:(NSURL *)redirectURL
+             redirectURL:(nullable NSURL *)redirectURL
                 clientID:(NSString *)clientID
             clientSecret:(nullable NSString *)clientSecret
                    scope:(nullable NSString *)scope
@@ -137,6 +138,16 @@ static NSString *const kAdditionalParametersKey = @"additionalParameters";
     _codeVerifier = [codeVerifier copy];
     _additionalParameters =
         [[NSDictionary alloc] initWithDictionary:additionalParameters copyItems:YES];
+    
+    // Additional validation for the authorization_code grant type
+    if ([_grantType isEqual:OIDGrantTypeAuthorizationCode]) {
+      // redirect URI must not be nil
+      if (!_redirectURL) {
+        [NSException raise:OIDOAuthExceptionInvalidTokenRequestNullRedirectURL
+                    format:@"%@", OIDOAuthExceptionInvalidTokenRequestNullRedirectURL, nil];
+
+      }
+    }
   }
   return self;
 }

--- a/UnitTests/OIDTokenRequestTests.m
+++ b/UnitTests/OIDTokenRequestTests.m
@@ -110,7 +110,7 @@ static NSString *const kTestAdditionalParameterValue = @"1";
       [[OIDTokenRequest alloc] initWithConfiguration:authResponse.request.configuration
                                            grantType:OIDGrantTypeAuthorizationCode
                                    authorizationCode:authResponse.authorizationCode
-                                         redirectURL:authResponse.request.redirectURL
+                                         redirectURL:nil
                                             clientID:authResponse.request.clientID
                                         clientSecret:authResponse.request.clientSecret
                                               scopes:scopesArray
@@ -219,6 +219,24 @@ static NSString *const kTestAdditionalParameterValue = @"1";
 
   id authorization = [urlRequest.allHTTPHeaderFields objectForKey:@"Authorization"];
   XCTAssertNotNil(authorization);
+}
+
+- (void)testAuthorizationCodeNullRedirectURL {
+  OIDAuthorizationResponse *authResponse = [OIDAuthorizationResponseTests testInstance];
+  NSArray<NSString *> *scopesArray =
+      [OIDScopeUtilities scopesArrayWithString:authResponse.request.scope];
+  NSDictionary *additionalParameters =
+      @{ kTestAdditionalParameterKey : kTestAdditionalParameterValue };
+  XCTAssertThrows([[OIDTokenRequest alloc] initWithConfiguration:authResponse.request.configuration
+                                                       grantType:OIDGrantTypeAuthorizationCode
+                                               authorizationCode:authResponse.authorizationCode
+                                                     redirectURL:nil
+                                                        clientID:authResponse.request.clientID
+                                                    clientSecret:authResponse.request.clientSecret
+                                                          scopes:scopesArray
+                                                    refreshToken:kRefreshTokenTestValue
+                                                    codeVerifier:authResponse.request.codeVerifier
+                                            additionalParameters:additionalParameters], @"");
 }
 
 @end


### PR DESCRIPTION
On close inspection of RFC 6749 Section 6, the refresh_uri isn't required and may cause issues on servers that are not expecting it.

RedirectURL is now nullable on the TokenRequest. To avoid inconsistencies, added a runtime check for nonnull values for supported grant types that require it.